### PR TITLE
Add joomla logger to stdout

### DIFF
--- a/src/Joomlatools/Composer/ExtensionInstaller.php
+++ b/src/Joomlatools/Composer/ExtensionInstaller.php
@@ -14,7 +14,7 @@ use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
 use Composer\Repository\InstalledRepositoryInterface;
 use Composer\Installer\LibraryInstaller;
-
+use \JLog as JLog;
 /**
  * Composer installer class
  *
@@ -171,6 +171,10 @@ class ExtensionInstaller extends LibraryInstaller
             require_once JPATH_LIBRARIES . '/import.php';
 
             require_once JPATH_LIBRARIES . '/cms.php';
+            
+            // Add logger to standard out for error messages during install
+            require_once JPATH_LIBRARIES . '/joomla/log/log.php';               
+            JLog::addLogger(array('logger' => 'echo'), JLog::ALL);
         }
 
         if(!($this->_application instanceof Application))

--- a/src/Joomlatools/Composer/ExtensionInstaller.php
+++ b/src/Joomlatools/Composer/ExtensionInstaller.php
@@ -173,8 +173,8 @@ class ExtensionInstaller extends LibraryInstaller
             require_once JPATH_LIBRARIES . '/cms.php';
             
             // Add logger to standard out for error messages during install
-            require_once JPATH_LIBRARIES . '/joomla/log/log.php';               
-            JLog::addLogger(array('logger' => 'echo'), JLog::ALL);
+            require_once JPATH_LIBRARIES . '/joomla/log/log.php';
+            JLog::addLogger(array('logger' => 'echo'), JLog::WARNING, array('jerror'));
         }
 
         if(!($this->_application instanceof Application))


### PR DESCRIPTION
When there is an error in the installer joomla simply logs it, by adding the echo logger you see the output in the terminal example:

```
    Cloning a13e35d8a70ba28789667b054dd2cfaf32cf3a2a

    Installing into Joomla

WARNING: JInstaller: :Install: File does not exist tmp/picturae/com_searchall/administrator/components/com_search_all/search_all.xml [jerror]
WARNING: Component Install: Failed to copy admin files. [jerror]



  [RuntimeException]
  Error while installing picturae/com_searchall
```