### PR TITLE
Fixed: PHP Fatal error: Cannot redeclare Composer\Autoload\includeFile()

### DIFF
--- a/src/Joomlatools/Composer/Application.php
+++ b/src/Joomlatools/Composer/Application.php
@@ -394,10 +394,17 @@ class Application extends JApplicationCli
  * Workaround for Joomla 3.4+
  * 
  * Fix Fatal error: Call to undefined function Composer\Autoload\includeFile() in /libraries/ClassLoader.php on line 43
+ *
+ * Fix Fatal error: Cannot redeclare Composer\Autoload\includeFile() (previously declared in
+ *  phar:///usr/bin/composer/vendor/composer/ClassLoader.php:410) in /vendor/joomlatools/installer/src/Joomlatools/Composer/Application.php
+ *  on line 403
  */
 namespace Composer\Autoload;
 
-function includeFile($file)
+if( !function_exists('Composer\Autoload\includeFile') )
 {
-    include $file;
+    function includeFile($file)
+    {
+        include $file;
+    }
 }


### PR DESCRIPTION
As of this morning, upon running `composer install`, or `composer update` the following error message is triggered:

```
PHP Fatal error: Cannot redeclare Composer\Autoload\includeFile() (previously declared in phar:///var/www/vhosts/foobar/composer.phar/vendor/composer/ClassLoader.php:410) in /var/www/vhosts/foobar/vendor/joomlatools/installer/src/Joomlatools/Composer/Application.php on line 403
```

I created a check whether the Composer\Autoload\includeFile() exists. If not, it is declared as per usual. 

This fix has been tested for Joomla version 3.3.X. I have no 2.5 versions available.