### PR TITLE
Hotfix/existing dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ in 1.x versions.
 To get the diff for a specific change, go to https://github.com/joomlatools/joomla-composer/commit/xxx where xxx is the change hash.
 To view the diff between two versions, go to https://github.com/joomlatools/joomla-composer/compare/v1.0.0...v1.0.1
 
+* 1.0.4 (2015-05-19)
+
+ * Added - Enable Joomla logging (PR #4)
+
+* 1.0.3 (2015-05-02)
+
+ * Fixed - Ensure compatibility with both latest Composer (Composer version 1.0-dev (1cb427ff5c0b977468643a39436f3b0a356fc8eb) 2015-04-26) and previous versions. (PR #5)
+
 * 1.0.2 (2015-03-03)
 
  * Fixed - Fix call to undefined function Composer\Autoload\includeFile() error in Joomla 3.4

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,6 @@
         "class": "Joomlatools\\Composer\\ExtensionInstallerPlugin"
     },
     "require": {
-        "composer-plugin-api": "1.0.0"
+        "composer-plugin-api": "^1.0"
     }
 }

--- a/src/Joomlatools/Composer/ExtensionInstaller.php
+++ b/src/Joomlatools/Composer/ExtensionInstaller.php
@@ -147,8 +147,12 @@ class ExtensionInstaller extends LibraryInstaller
     public function isInstalled(InstalledRepositoryInterface $repo, PackageInterface $package)
     {
         $installer = $this->_application->getInstaller();
-        $installer->setPath('source', $this->getInstallPath($package));
-
+        $installPath = $this->getInstallPath($package);
+        if (!is_dir($installPath)) {
+            return false;
+        }
+        $installer->setPath('source', $installPath);
+        
         $manifest = $installer->getManifest();
 
         if($manifest)


### PR DESCRIPTION
When the tmp path is empty but the components are already installed i get an error like below.
Checking for the install path seems to work.

```
WARNING: JFolder: :files: Path is not a folder. Path: tmp/picturae/com_archive [jerror]
WARNING: JFolder: :files: Path is not a folder. Path: tmp/picturae/com_archive [jerror]



  [ErrorException]
  array_merge(): Argument #1 is not an array



Exception trace:
 () at /Users/cdekok/Projects/hni.jos.picturae.pro/public/libraries/cms/installer/installer.php:1875
 Composer\Util\ErrorHandler::handle() at n/a:n/a
 array_merge() at /Users/cdekok/Projects/hni.jos.picturae.pro/public/libraries/cms/installer/installer.php:1875
 JInstaller->findManifest() at /Users/cdekok/Projects/hni.jos.picturae.pro/public/libraries/cms/installer/installer.php:276
 JInstaller->getManifest() at /Users/cdekok/Projects/hni.jos.picturae.pro/cust-hni-website/external-src/src/vendor/joomlatools/installer/src/Joomlatools/Composer/ExtensionInstaller.php:151
 Joomlatools\Composer\ExtensionInstaller->isInstalled() at phar:///Users/cdekok/bin/composer/src/Composer/Installer/InstallationManager.php:127
 Composer\Installer\InstallationManager->isPackageInstalled() at phar:///Users/cdekok/bin/composer/src/Composer/Factory.php:469
 Composer\Factory->purgePackages() at phar:///Users/cdekok/bin/composer/src/Composer/Factory.php:300
 Composer\Factory->createComposer() at phar:///Users/cdekok/bin/composer/src/Composer/Factory.php:486
 Composer\Factory::create() at phar:///Users/cdekok/bin/composer/src/Composer/Console/Application.php:222
 Composer\Console\Application->getComposer() at phar:///Users/cdekok/bin/composer/src/Composer/Command/Command.php:53
 Composer\Command\Command->getComposer() at phar:///Users/cdekok/bin/composer/src/Composer/Command/UpdateCommand.php:86
 Composer\Command\UpdateCommand->execute() at phar:///Users/cdekok/bin/composer/vendor/symfony/console/Symfony/Component/Console/Command/Command.php:257
 Symfony\Component\Console\Command\Command->run() at phar:///Users/cdekok/bin/composer/vendor/symfony/console/Symfony/Component/Console/Application.php:874
 Symfony\Component\Console\Application->doRunCommand() at phar:///Users/cdekok/bin/composer/vendor/symfony/console/Symfony/Component/Console/Application.php:195
 Symfony\Component\Console\Application->doRun() at phar:///Users/cdekok/bin/composer/src/Composer/Console/Application.php:146
 Composer\Console\Application->doRun() at phar:///Users/cdekok/bin/composer/vendor/symfony/console/Symfony/Component/Console/Application.php:126
 Symfony\Component\Console\Application->run() at phar:///Users/cdekok/bin/composer/src/Composer/Console/Application.php:82
 Composer\Console\Application->run() at phar:///Users/cdekok/bin/composer/bin/composer:43
 require() at /Users/cdekok/bin/composer:25
```