### PR TITLE
Check if path is available and then set file, this lets us handle zipped plugins in a package correctly

### DIFF
--- a/src/Joomlatools/Composer/ExtensionInstaller.php
+++ b/src/Joomlatools/Composer/ExtensionInstaller.php
@@ -83,8 +83,6 @@ class ExtensionInstaller
             throw new \RuntimeException($error);
         }
 
-        $this->_enablePlugin($package, $installPath);
-
         if ($copied_files) {
             foreach ($copied_files as $file) {
                 if (is_file($file)) {
@@ -282,54 +280,5 @@ class ExtensionInstaller
         }
 
         return $descriptions;
-    }
-
-    /**
-     * Enable all plugins that were installed with this package.
-     *
-     * @param PackageInterface $package
-     * @param string           $subdirectory Subdirectory in package install path to look for plugin manifests
-     */
-    protected function _enablePlugin(PackageInterface $package, $installPath, $subdirectory = '')
-    {
-        $file = false;
-        $path = realpath($installPath . '/' . $subdirectory);
-
-        if($path !== false)
-        {
-            $file = Util::getPackageManifest($path);
-        }
-
-        if($file !== false)
-        {
-            $manifest = simplexml_load_file($file);
-            $type     = (string) $manifest->attributes()->type;
-
-            if ($type == 'plugin')
-            {
-                $name  = Util::getNameFromManifest($installPath);
-                $group = (string) $manifest->attributes()->group;
-
-                $extension = Bootstrapper::getInstance()->getApplication()->getExtension($name, 'plugin', $group);
-
-                if (is_object($extension) && $extension->id > 0)
-                {
-                    $sql = "UPDATE `#__extensions`"
-                        ." SET `enabled` = 1"
-                        ." WHERE `extension_id` = ".$extension->id;
-
-                    \JFactory::getDbo()->setQuery($sql)->execute();
-                }
-            }
-            elseif ($type == 'package')
-            {
-                foreach($manifest->files->children() as $file)
-                {
-                    if ((string) $file->attributes()->type == 'plugin') {
-                        $this->_enablePlugin($package, $installPath, (string) $file);
-                    }
-                }
-            }
-        }
     }
 }

--- a/src/Joomlatools/Composer/ExtensionInstaller.php
+++ b/src/Joomlatools/Composer/ExtensionInstaller.php
@@ -292,8 +292,13 @@ class ExtensionInstaller
      */
     protected function _enablePlugin(PackageInterface $package, $installPath, $subdirectory = '')
     {
+        $file = false;
         $path = realpath($installPath . '/' . $subdirectory);
-        $file = Util::getPackageManifest($path);
+
+        if($path !== false)
+        {
+            $file = Util::getPackageManifest($path);
+        }
 
         if($file !== false)
         {


### PR DESCRIPTION
`<?xml version="1.0" encoding="UTF-8" ?>
<extension type="package" version="2.5" method="upgrade">
  <name>PKG_JCE</name>
  <author>Ryan Demmer</author>
  <creationDate>21-03-2018</creationDate>
  <packagename>jce</packagename>
  <version>2.6.28</version>
  <url>https://www.joomlacontenteditor.net</url>
  <packager>Widget Factory Limited</packager>
  <packagerurl>https://www.joomlacontenteditor.net</packagerurl>
  <description>PKG_JCE_XML_DESCRIPTION</description>
  <updateservers>
    <server type="collection" priority="1" name="JCE Editor Package">
      <![CDATA[https://cdn.joomlacontenteditor.net/updates/xml/pkg_jce_pro.xml]]>
    </server>
  </updateservers>
  <scriptfile>install.pkg.php</scriptfile>
  <files folder="packages">
    <file type="component" id="com_jce">com_jce.zip</file>
    <file type="plugin" id="jce" group="editors">plg_editors_jce.zip</file>
    <file type="plugin" id="jce" group="content">plg_content_jce.zip</file>
    <file type="plugin" id="jce" group="extension">plg_extension_jce.zip</file>
    <file type="plugin" id="jce" group="fields">plg_fields_mediajce.zip</file>
    <file type="plugin" id="jce" group="installer">plg_installer_jce.zip</file>
    <file type="plugin" id="jce" group="quickicon">plg_quickicon_jce.zip</file>
    <file type="plugin" id="jce" group="system">plg_system_jce.zip</file>
  </files>
  <languages folder="language">
    <language tag="en-GB">en-GB/en-GB.pkg_jce.sys.ini</language>
  </languages>
  <variant>pro</variant>
  <compatibility>
    <version>2</version>
    <version>3</version>
  </compatibility>
</extension>`

The following package wouldn't install correctly because of the zips. This change handles a manifest file for a package correctly.